### PR TITLE
Increase game difficulty

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -18,11 +18,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // ===== Round Config =====
   const ROUNDS = [
-    { duration: 5, visibleWindow: 3000, maxActive: 3, pointsPerEgg: 10 },
-    { duration: 5, visibleWindow: 2500, maxActive: 4, pointsPerEgg: 15 },
-    { duration: 10, visibleWindow: 2000, maxActive: 5, pointsPerEgg: 20 },
-    { duration: 10, visibleWindow: 1500, maxActive: 6, pointsPerEgg: 25 },
-    { duration: 10, visibleWindow: 1200, maxActive: 7, pointsPerEgg: 30 },
+    { duration: 10, visibleWindow: 2000, maxActive: 5, pointsPerEgg: 10 },
+    { duration: 10, visibleWindow: 1500, maxActive: 6, pointsPerEgg: 15 },
+    { duration: 10, visibleWindow: 1200, maxActive: 7, pointsPerEgg: 20 },
+    { duration: 10, visibleWindow: 1000, maxActive: 8, pointsPerEgg: 25 },
+    { duration: 10, visibleWindow: 800, maxActive: 9, pointsPerEgg: 30 },
   ];
 
   const CLEAN_SWEEP_BONUS = 50;


### PR DESCRIPTION
## Summary
- Round 1 now starts at the old round 3 difficulty (2000ms visible window, 5 max active eggs)
- Each round scales up harder than before, with rounds 4-5 reaching 1000ms/800ms visible windows and 8-9 active eggs
- All rounds are 10 seconds

## Test plan
- [ ] Play through all 5 rounds and confirm increased difficulty
- [ ] Verify round 1 feels appropriately challenging (not too easy)
- [ ] Confirm rounds 4-5 are hard but still playable