### PR TITLE
Reduce to 3 fast rounds for mobile difficulty

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
   <!-- HUD Bar -->
   <div id="hud" class="hidden">
     <span id="hud-score">Score: 0</span>
-    <span id="hud-round">Round 1/5</span>
-    <span id="hud-timer">Time: 20s</span>
+    <span id="hud-round">Round 1 of 3</span>
+    <span id="hud-timer">Time: 8s</span>
     <span id="hud-combo" class="hidden">x2</span>
   </div>
 
@@ -40,9 +40,9 @@
     <div class="how-to-play-card">
       <h2>How to play</h2>
       <ul>
-        <li><strong>5 rounds</strong> of tapping eggs before they disappear</li>
+        <li><strong>3 rounds</strong> of tapping eggs before they disappear</li>
         <li>Each round gets harder: eggs vanish faster and more appear at once</li>
-        <li>Points per egg increase each round (10, 15, 20, 25, 30)</li>
+        <li>Points per egg increase each round (10, 20, 30)</li>
         <li><strong>Combo:</strong> collect eggs within 1 second for up to a 3x multiplier</li>
         <li>Each egg gives you a random candy. Try to find all 14!</li>
       </ul>

--- a/public/script.js
+++ b/public/script.js
@@ -18,11 +18,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // ===== Round Config =====
   const ROUNDS = [
-    { duration: 10, visibleWindow: 2000, maxActive: 5, pointsPerEgg: 10 },
-    { duration: 10, visibleWindow: 1500, maxActive: 6, pointsPerEgg: 15 },
-    { duration: 10, visibleWindow: 1200, maxActive: 7, pointsPerEgg: 20 },
-    { duration: 10, visibleWindow: 1000, maxActive: 8, pointsPerEgg: 25 },
-    { duration: 10, visibleWindow: 800, maxActive: 9, pointsPerEgg: 30 },
+    { duration: 8, visibleWindow: 1500, maxActive: 3, pointsPerEgg: 10 },
+    { duration: 8, visibleWindow: 1000, maxActive: 4, pointsPerEgg: 20 },
+    { duration: 8, visibleWindow: 800, maxActive: 5, pointsPerEgg: 30 },
   ];
 
   const CLEAN_SWEEP_BONUS = 50;


### PR DESCRIPTION
## Summary
- 3 rounds instead of 5 (8 seconds each)
- Fewer max active eggs per round (3, 4, 5) so players hunt rather than mash
- Fast despawns from round 1 (1500ms, 1000ms, 800ms)
- Total game time drops from ~50s to ~24s, making high scores more meaningful
- Updated How to Play and HUD defaults

## Test plan
- [ ] Play on mobile — confirm it feels harder than before
- [ ] Play on desktop — confirm still fun
- [ ] Verify How to Play text says 3 rounds with correct point values
- [ ] Verify HUD shows "Round N of 3"